### PR TITLE
remove numeric arguments from minimist's string option.

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,7 +127,7 @@ var argv = minimist(process.argv, {
     e: 'env'
   },
   boolean: ['ffmpeg_logging', 'debug', 'logout', 'session', 'cache', 'version', 'free', 'env'],
-  string: ['port', 'account_username', 'account_password', 'zip_code', 'country', 'fav_teams', 'multiview_port', 'multiview_path', 'ffmpeg_path', 'ffmpeg_encoder', 'page_username', 'page_password', 'content_protect', 'gamechanger_delay', 'data_directory']
+  string: ['account_username', 'account_password', 'zip_code', 'country', 'fav_teams', 'multiview_path', 'ffmpeg_path', 'ffmpeg_encoder', 'page_username', 'page_password', 'content_protect', 'data_directory']
 })
 
 if (argv.env) argv = process.env


### PR DESCRIPTION
`port`, `multiview_port`, and `gamechanger_delay` represent numeric values.

Running `mlbserver -p 9996` results in error:

```
RangeError [ERR_SOCKET_BAD_PORT]: options.port should be >= 0 and < 65536. Received type string ('99961').
```

This is because listing `port` in the `string` option passed to minimist tells minimist to interpret `port` as a string.  And adding 1 to the port concatenates.  By removing `port` (and the other two numeric options) from the `string` array, minimist correctly interprets the value as numeric, and adding 1 to 9996 yields 9997, as intended.