### PR TITLE
Dockerfile: Add OCI source label for automated changelogs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM node:16-alpine
 
+LABEL org.opencontainers.image.source="https://github.com/tonywagner/mlbserver"
+
 RUN apk update && apk add tzdata
 
 # Create app directory


### PR DESCRIPTION
Small PR to add OCI source label for automated changelogs from dependency management platforms such as Renovate. 

Reference: https://github.com/opencontainers/image-spec/blob/main/annotations.md