### PR TITLE
add login/logout functionality with cookie-based authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ Basic command line or Docker environment options:
 --session or -s (clears session)
 --cache or -c (clears cache)
 --env or -e (use environment variables instead of command line arguments; automatically applied in the Docker image)
+--login_page or -lp (false if not specified, login is done via a login page and uses cookies)
 ```
 
 Advanced command line or Docker environment options:
@@ -68,6 +69,7 @@ Advanced command line or Docker environment options:
 --page_username (username to protect pages; default is no protection)
 --page_password (password to protect pages; default is no protection)
 --content_protect (specify the content protection key to include as a URL parameter, if page protection is enabled)
+--login_page (optional, enable login page authentication; default is false, uses browswer popup when unset)
 --gamechanger_delay (specify extra delay for the gamechanger switches in 10 second increments, default is 0)
 --data_directory (defaults to installed application directory; in the Docker image, this defaults to /mlbserver/data_directory for mapping persistent storage)
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,7 @@ services:
       #- page_username=
       #- page_password=
       #- content_protect=
+      #- login_page=false
       #- gamechanger_delay=0
       #- PUID=1000
       #- PGID=1000

--- a/index.js
+++ b/index.js
@@ -1363,7 +1363,48 @@ function isAuthenticated(req) {
   return token === session.protection.content_protect;
 }
 
+const AUTH_TOKEN_TTL = 24 * 60 * 60 * 1000; // 1 day
+const authenticatedSessions = new Map();
+
+function isSecure(req) {
+  const forwarded = req.headers['x-forwarded-proto'];
+  if (forwarded) {
+    return forwarded.split(',')[0].trim().toLowerCase() === 'https';
+  }
+  return (req.connection && req.connection.encrypted) || false;
+}
+
+function cleanupExpiredSessions() {
+  const now = Date.now();
+  for (const [token, sessionData] of authenticatedSessions.entries()) {
+    if (sessionData.expiry <= now) {
+      authenticatedSessions.delete(token);
+    }
+  }
+}
+
+function isAuthenticated(req) {
+  if (!req.headers.cookie) return false;
+  const cookies = req.headers.cookie.split(';').map(c => c.trim());
+  const authCookie = cookies.find(c => c.startsWith('auth_token='));
+  if (!authCookie) return false;
+
+  const token = authCookie.split('=')[1];
+  const sessionData = authenticatedSessions.get(token);
+  if (!sessionData) return false;
+
+  if (sessionData.expiry <= Date.now()) {
+    authenticatedSessions.delete(token);
+    return false;
+  }
+
+  sessionData.expiry = Date.now() + AUTH_TOKEN_TTL;
+  return true;
+}
+
 async function protect(req, res) {
+  cleanupExpiredSessions();
+
   if (argv.page_username && argv.page_password) {
     if ( !session.protection.content_protect || !req.query.content_protect || (req.query.content_protect != session.protection.content_protect) ) {
       if ( !session.protection.content_protect || !req.query.content_protect || !req.query.content_protect[0] || (req.query.content_protect[0] != session.protection.content_protect) ) {
@@ -1371,28 +1412,26 @@ async function protect(req, res) {
           // Already authenticated via cookie
         } else {
           if (argv.login_page) {
-            // Redirect to login page
             const redirectUrl = encodeURIComponent(req.url);
             res.writeHead(302, { 'Location': http_root + '/login?redirect=' + redirectUrl });
             res.end();
             return false;
           } else {
-            // Use browser popup
             const reject = () => {
               res.setHeader('www-authenticate', 'Basic');
               res.error(401, ' Not Authorized');
               return false;
-            };
+            }
 
             const authorization = req.headers.authorization;
 
-            if(!authorization) {
+            if (!authorization) {
               return reject();
             }
 
             const [username, password] = Buffer.from(authorization.replace('Basic ', ''), 'base64').toString().split(':');
 
-            if(! (username === argv.page_username && password === argv.page_password)) {
+            if (! (username === argv.page_username && password === argv.page_password)) {
               return reject();
             }
           }
@@ -1430,6 +1469,12 @@ app.get('/login', async function(req, res) {
   }
 });
 
+function getCookieOptions(req) {
+  const options = ['HttpOnly', 'Path=/', 'SameSite=Strict'];
+  if (isSecure(req)) options.push('Secure');
+  return options.join('; ');
+}
+
 // Login POST handler
 app.post('/login', async function(req, res) {
   try {
@@ -1445,9 +1490,11 @@ app.post('/login', async function(req, res) {
       const password = params.get('password');
       const redirect = params.get('redirect') || '/';
       if (username === argv.page_username && password === argv.page_password) {
+        const token = crypto.randomBytes(16).toString('hex');
+        authenticatedSessions.set(token, { expiry: Date.now() + AUTH_TOKEN_TTL });
         res.writeHead(302, {
           'Location': redirect,
-          'Set-Cookie': `auth_token=${session.protection.content_protect}; HttpOnly; Path=/`
+          'Set-Cookie': `auth_token=${token}; ${getCookieOptions(req)}`
         });
         res.end();
       } else {
@@ -1468,9 +1515,18 @@ app.get('/logout', async function(req, res) {
       res.error(404, 'Not Found');
       return;
     }
+    let token = '';
+    if (req.headers.cookie) {
+      const cookies = req.headers.cookie.split(';').map(c => c.trim());
+      const authCookie = cookies.find(c => c.startsWith('auth_token='));
+      if (authCookie) token = authCookie.split('=')[1];
+    }
+    if (token && authenticatedSessions.has(token)) {
+      authenticatedSessions.delete(token);
+    }
     res.writeHead(302, {
       'Location': '/',
-      'Set-Cookie': 'auth_token=; HttpOnly; Path=/; Max-Age=0'
+      'Set-Cookie': `auth_token=; ${getCookieOptions(req)}; Max-Age=0`
     });
     res.end();
   } catch (e) {

--- a/index.js
+++ b/index.js
@@ -129,9 +129,10 @@ var argv = minimist(process.argv, {
     s: 'session',
     c: 'cache',
     v: 'version',
-    e: 'env'
+    e: 'env',
+    lp: 'login_page'
   },
-  boolean: ['ffmpeg_logging', 'debug', 'logout', 'session', 'cache', 'version', 'free', 'env'],
+  boolean: ['ffmpeg_logging', 'debug', 'logout', 'session', 'cache', 'version', 'free', 'env', 'login_page'],
   string: ['account_username', 'account_password', 'fav_teams', 'multiview_path', 'ffmpeg_path', 'ffmpeg_encoder', 'page_username', 'page_password', 'content_protect', 'data_directory', 'http_root']
 })
 
@@ -1353,31 +1354,53 @@ app.get('/gamechangerplaylist.m3u8', async function(req, res) {
 })
 
 // Protect pages by password, or content by content_protect url parameter
+function isAuthenticated(req) {
+  if (!req.headers.cookie) return false;
+  const cookies = req.headers.cookie.split(';').map(c => c.trim());
+  const authCookie = cookies.find(c => c.startsWith('auth_token='));
+  if (!authCookie) return false;
+  const token = authCookie.split('=')[1];
+  return token === session.protection.content_protect;
+}
+
 async function protect(req, res) {
   if (argv.page_username && argv.page_password) {
     if ( !session.protection.content_protect || !req.query.content_protect || (req.query.content_protect != session.protection.content_protect) ) {
       if ( !session.protection.content_protect || !req.query.content_protect || !req.query.content_protect[0] || (req.query.content_protect[0] != session.protection.content_protect) ) {
-        const reject = () => {
-          res.setHeader('www-authenticate', 'Basic')
-          res.error(401, ' Not Authorized')
-          return false
-        }
+        if (argv.login_page && isAuthenticated(req)) {
+          // Already authenticated via cookie
+        } else {
+          if (argv.login_page) {
+            // Redirect to login page
+            const redirectUrl = encodeURIComponent(req.url);
+            res.writeHead(302, { 'Location': http_root + '/login?redirect=' + redirectUrl });
+            res.end();
+            return false;
+          } else {
+            // Use browser popup
+            const reject = () => {
+              res.setHeader('www-authenticate', 'Basic');
+              res.error(401, ' Not Authorized');
+              return false;
+            };
 
-        const authorization = req.headers.authorization
+            const authorization = req.headers.authorization;
 
-        if(!authorization) {
-          return reject()
-        }
+            if(!authorization) {
+              return reject();
+            }
 
-        const [username, password] = Buffer.from(authorization.replace('Basic ', ''), 'base64').toString().split(':')
+            const [username, password] = Buffer.from(authorization.replace('Basic ', ''), 'base64').toString().split(':');
 
-        if(! (username === argv.page_username && password === argv.page_password)) {
-          return reject()
+            if(! (username === argv.page_username && password === argv.page_password)) {
+              return reject();
+            }
+          }
         }
       }
     }
   }
-  return true
+  return true;
 }
 
 function getLastName(fullName) {
@@ -1389,6 +1412,72 @@ function getLastName(fullName) {
 
   return fullName.substring(indexOfSpace + 1);
 }
+
+// Login page
+app.get('/login', async function(req, res) {
+  try {
+    if (!argv.login_page) {
+      res.error(404, 'Not Found');
+      return;
+    }
+    const redirect = req.query.redirect || '/';
+    const error = req.query.error ? '<p style="color:red;">Invalid username or password</p>' : '';
+    res.writeHead(200, {'Content-Type': 'text/html'});
+    res.end(`<!DOCTYPE html><html><head><meta charset="UTF-8"><title>Login - ${appname}</title><style>body{color:lightgray;background-color:black;font-family:Arial,Helvetica,sans-serif;}input{background-color:black;color:lightgray;border:1px solid lightgray;}button{background-color:black;color:lightgray;border:1px solid lightgray;}</style></head><body><h1>Login to ${appname}</h1>${error}<form method="POST" action="${http_root}/login"><input type="hidden" name="redirect" value="${redirect}"><p>Username: <input type="text" name="username" required></p><p>Password: <input type="password" name="password" required></p><p><button type="submit">Login</button></p></form></body></html>`);
+  } catch (e) {
+    session.log('login get request error : ' + e.message);
+    res.end('login get request error, check log');
+  }
+});
+
+// Login POST handler
+app.post('/login', async function(req, res) {
+  try {
+    if (!argv.login_page) {
+      res.error(404, 'Not Found');
+      return;
+    }
+    let body = '';
+    req.on('data', chunk => { body += chunk.toString(); });
+    req.on('end', () => {
+      const params = new URLSearchParams(body);
+      const username = params.get('username');
+      const password = params.get('password');
+      const redirect = params.get('redirect') || '/';
+      if (username === argv.page_username && password === argv.page_password) {
+        res.writeHead(302, {
+          'Location': redirect,
+          'Set-Cookie': `auth_token=${session.protection.content_protect}; HttpOnly; Path=/`
+        });
+        res.end();
+      } else {
+        res.writeHead(302, { 'Location': `${http_root}/login?redirect=${encodeURIComponent(redirect)}&error=1` });
+        res.end();
+      }
+    });
+  } catch (e) {
+    session.log('login post request error : ' + e.message);
+    res.end('login post request error, check log');
+  }
+});
+
+// Logout
+app.get('/logout', async function(req, res) {
+  try {
+    if (!argv.login_page) {
+      res.error(404, 'Not Found');
+      return;
+    }
+    res.writeHead(302, {
+      'Location': '/',
+      'Set-Cookie': 'auth_token=; HttpOnly; Path=/; Max-Age=0'
+    });
+    res.end();
+  } catch (e) {
+    session.log('logout request error : ' + e.message);
+    res.end('logout request error, check log');
+  }
+});
 
 // Server homepage, base URL
 app.get('/', async function(req, res) {
@@ -1569,6 +1658,10 @@ app.get('/', async function(req, res) {
     body += 'document.addEventListener("touchstart", function() {}, true);' + "\n"
 
 		body += '</script></head><body><h1>' + appname + '</h1>' + "\n"
+
+    if (argv.login_page) {
+      body += '<p><a href="' + http_root + '/logout">Logout</a></p>' + "\n"
+    }
 
     body += '<p><span class="tooltip tinytext">Touch or hover over an option name for more details</span></p>' + "\n"
 


### PR DESCRIPTION
Add --login_page flag to enable login form authentication instead of browser popup, with cookie-based auth and logout functionality. Maintains backward compatibility with existing HTTP Basic Auth by using it by default.