### PR TITLE
Modal width, condensed game on top, response json

### DIFF
--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ var ffmpeg_status = false
 
 // Start web server listening on port
 // and also multiview server on its port (next one if not defined otherwise)
-let port = argv.port || 9669
+let port = argv.port || 9999
 let multiview_port = argv.multiview_port || port + 1
 session.setPorts(port, multiview_port)
 app.listen(port, function(addr) {

--- a/index.js
+++ b/index.js
@@ -1692,7 +1692,7 @@ app.get('/', async function(req, res) {
     var body = '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="Content-type" content="text/html;charset=UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"><title>' + appname + '</title><link rel="icon" href="favicon.svg' + content_protect_a + '"><style type="text/css">input[type=text],input[type=button]{-webkit-appearance:none;-webkit-border-radius:0}body{width:480px;color:lightgray;background-color:black;font-family:Arial,Helvetica,sans-serif;-webkit-text-size-adjust:none}a{color:darkgray}button{color:lightgray;background-color:black}button.default{color:black;background-color:lightgray}table{width:100%;pad}table,th,td{border:1px solid darkgray;border-collapse:collapse}th,td{padding:5px}.tinytext,textarea,input[type="number"]{font-size:.8em}textarea{width:380px}.freegame,.freegame a{color:green}.blackout,.blackout a{text-decoration:line-through}'
 
     // Highlights CSS
-    body += '.modal{display:none;position:fixed;z-index:1;left:0;top:0;width:100%;height:100%;overflow:hidden;background-color:rgb(0,0,0);background-color:rgba(0,0,0,0.4)}.modal-content{position:absolute;top:100px;bottom:20px;left:50%;transform:translateX(-50%);background-color:#fefefe;padding:10px;border:1px solid #888;width:360px;overflow-y:auto;color:black}#highlights{overflow-y:auto;}#highlights a{color:black}.close{color:black;float:right;font-size:28px;font-weight:bold;}#highlights a:hover,#highlights a:focus,.close:hover,.close:focus{color:gray;text-decoration:none;cursor:pointer;}'
+    body += '.modal{display:none;position:fixed;z-index:1;left:0;top:0;width:100%;height:100%;overflow:hidden;background-color:rgb(0,0,0);background-color:rgba(0,0,0,0.4)}.modal-content{position:absolute;top:100px;bottom:20px;left:50%;transform:translateX(-50%);background-color:#fefefe;padding:10px;border:1px solid #888;width:560px;overflow-y:auto;color:black}#highlights{overflow-y:auto;}#highlights a{color:black}.close{color:black;float:right;font-size:28px;font-weight:bold;}#highlights a:hover,#highlights a:focus,.close:hover,.close:focus{color:gray;text-decoration:none;cursor:pointer;}'
 
     // Tooltip CSS
     body += '.tooltip{position:relative;display:inline-block;border-bottom: 1px dotted gray;}.tooltip .tooltiptext{font-size:.8em;visibility:hidden;width:360px;background-color:gray;color:white;text-align:left;padding:5px;border-radius:6px;position:absolute;z-index:1;top:100%;left:75%;margin-left:-30px;}.tooltip:hover .tooltiptext{visibility:visible;}'
@@ -2781,20 +2781,34 @@ function parsehighlightsresponse(responsetext) {
       captions_parameter = '&captions=disabled';
     }
     if (highlights && (highlights.length > 0)) {
-      for (var i = 0; i < highlights.length; i++) {
+
+      function addhighlight(highlight) {
         var hls_url = '';
         var mp4_url = '';
-        if (highlights[i].playbacks && (highlights[i].playbacks.length > 0)) {
-          for (var j = 0; j < highlights[i].playbacks.length; j++) {
-            if (highlights[i].playbacks[j].name && (highlights[i].playbacks[j].name == 'HTTP_CLOUD_WIRED_60')) {
-              hls_url = highlights[i].playbacks[j].url;
-            } else if (highlights[i].playbacks[j].name && (highlights[i].playbacks[j].name == 'mp4Avc')) {
-              mp4_url = highlights[i].playbacks[j].url;
+        if (highlight.playbacks && (highlight.playbacks.length > 0)) {
+          for (var j = 0; j < highlight.playbacks.length; j++) {
+            if (highlight.playbacks[j].name && (highlight.playbacks[j].name == 'HTTP_CLOUD_WIRED_60')) {
+              hls_url = highlight.playbacks[j].url;
+            } else if (highlight.playbacks[j].name && (highlight.playbacks[j].name == 'mp4Avc')) {
+              mp4_url = highlight.playbacks[j].url;
             }
           }
         }
-        modaltext += "<li><a href='` + link + `?highlight_src=" + encodeURIComponent(hls_url) + "&resolution=" + resolution + captions_parameter + "` + content_protect_b + `'>" + highlights[i].headline + "</a><span class='tinytext'> (<a href='" + mp4_url + "'>MP4</a>)</span></li>";
+        modaltext += "<li><a href='` + link + `?highlight_src=" + encodeURIComponent(hls_url) + "&resolution=" + resolution + captions_parameter + "` + content_protect_b + `'>" + highlight.headline + "</a><span class='tinytext'> (<a href='" + mp4_url + "'>MP4</a>)</span></li>";
       }
+
+      for (var i = 0; i < highlights.length; i++) {
+        if (highlights[i].headline && highlights[i].headline.indexOf("Condensed Game") !== -1) {
+          addhighlight(highlights[i]);
+          modaltext += "<hr>";
+          break;
+  }
+}
+
+      for (var i = 0; i < highlights.length; i++) {
+        addhighlight(highlights[i]);
+      }
+
     } else {
       modaltext += "No highlights available for this game.";
     }
@@ -3324,6 +3338,7 @@ app.get('/highlights', async function(req, res) {
     if ( req.query.gamePk && req.query.gameDate ) {
       highlightsData = await session.getHighlightsData(req.query.gamePk, req.query.gameDate)
     }
+    res.writeHead(200, {'Content-Type': 'application/json; charset=utf-8'});
     res.end(JSON.stringify(highlightsData))
   } catch (e) {
     session.log('highlights request error : ' + e.message)

--- a/index.js
+++ b/index.js
@@ -227,7 +227,7 @@ var ffmpeg_status = false
 
 // Start web server listening on port
 // and also multiview server on its port (next one if not defined otherwise)
-let port = argv.port || 9999
+let port = argv.port || 9669
 let multiview_port = argv.multiview_port || port + 1
 session.setPorts(port, multiview_port)
 app.listen(port, function(addr) {
@@ -250,6 +250,24 @@ function corsMiddleware(req, res, next) {
 }
 httpAttach(multiview_app, corsMiddleware)
 multiview_app.listen(multiview_port)
+
+// Listen for stylesheet requests
+app.get('/style.css', async function (req, res) {
+  if (!(await protect(req, res))) return
+
+  session.requestlog('style.css', req, true)
+
+  var body = await session.getCSS()
+
+  if (!body) {
+    res.writeHead(404, { 'Content-Type': 'text/plain; charset=utf-8' })
+    res.end('style.css not found')
+    return
+  }
+
+  res.writeHead(200, { 'Content-Type': 'text/css; charset=utf-8' })
+  res.end(body)
+})
 
 // Listen for clear cache requests
 app.get('/clearcache', async function(req, res) {
@@ -1689,10 +1707,7 @@ app.get('/', async function(req, res) {
       content_protect_b = '&content_protect=' + content_protect
     }
 
-    var body = '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="Content-type" content="text/html;charset=UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"><title>' + appname + '</title><link rel="icon" href="favicon.svg' + content_protect_a + '"><style type="text/css">input[type=text],input[type=button]{-webkit-appearance:none;-webkit-border-radius:0}body{width:480px;color:lightgray;background-color:black;font-family:Arial,Helvetica,sans-serif;-webkit-text-size-adjust:none}a{color:darkgray}button{color:lightgray;background-color:black}button.default{color:black;background-color:lightgray}table{width:100%;pad}table,th,td{border:1px solid darkgray;border-collapse:collapse}th,td{padding:5px}.tinytext,textarea,input[type="number"]{font-size:.8em}textarea{width:380px}.freegame,.freegame a{color:green}.blackout,.blackout a{text-decoration:line-through}'
-
-    // Highlights CSS
-    body += '.modal{display:none;position:fixed;z-index:1;left:0;top:0;width:100%;height:100%;overflow:hidden;background-color:rgb(0,0,0);background-color:rgba(0,0,0,0.4)}.modal-content{position:absolute;top:100px;bottom:20px;left:50%;transform:translateX(-50%);background-color:#fefefe;padding:10px;border:1px solid #888;width:560px;overflow-y:auto;color:black}#highlights{overflow-y:auto;}#highlights a{color:black}.close{color:black;float:right;font-size:28px;font-weight:bold;}#highlights a:hover,#highlights a:focus,.close:hover,.close:focus{color:gray;text-decoration:none;cursor:pointer;}'
+    var body = '<!DOCTYPE html><html><head><meta charset="UTF-8"><meta http-equiv="Content-type" content="text/html;charset=UTF-8"><meta name="viewport" content="width=device-width,initial-scale=1,shrink-to-fit=no"><title>' + appname + '</title><link rel="icon" href="favicon.svg' + content_protect_a + '"><link rel="stylesheet" href="/style.css"><style type="text/css">input[type=text],input[type=button]{-webkit-appearance:none;-webkit-border-radius:0}body{max-width:480px;color:lightgray;background-color:black;font-family:Arial,Helvetica,sans-serif;-webkit-text-size-adjust:none}a{color:darkgray}button{color:lightgray;background-color:black}button.default{color:black;background-color:lightgray}table{width:100%;pad}table,th,td{border:1px solid darkgray;border-collapse:collapse}th,td{padding:5px}.tinytext,textarea,input[type="number"]{font-size:.8em}textarea{width:380px}.freegame,.freegame a{color:green}.blackout,.blackout a{text-decoration:line-through}'
 
     // Tooltip CSS
     body += '.tooltip{position:relative;display:inline-block;border-bottom: 1px dotted gray;}.tooltip .tooltiptext{font-size:.8em;visibility:hidden;width:360px;background-color:gray;color:white;text-align:left;padding:5px;border-radius:6px;position:absolute;z-index:1;top:100%;left:75%;margin-left:-30px;}.tooltip:hover .tooltiptext{visibility:visible;}'
@@ -2769,6 +2784,35 @@ app.get('/', async function(req, res) {
 
     // Highlights modal functions
     body += `<script type="text/javascript">
+    `
+
+    // Highlights modal positioning
+    body += `var pageScrollY = 0;
+
+    function openModal() {
+      pageScrollY = window.scrollY || document.documentElement.scrollTop;
+      document.body.style.position = "fixed";
+      document.body.style.top = "-" + pageScrollY + "px";
+      document.body.style.left = "0";
+      document.body.style.right = "0";
+      document.body.style.width = "100%";
+      document.body.style.overflow = "hidden";
+      modal.style.display = "flex";
+    }
+
+    function closeModal() {
+      document.body.style.position = "";
+      document.body.style.top = "";
+      document.body.style.left = "";
+      document.body.style.right = "";
+      document.body.style.width = "";
+      document.body.style.overflow = "";
+      window.scrollTo(0, pageScrollY);
+      modal.style.display = "none";
+    }
+      `
+
+  body += `
 var modal = document.getElementById("myModal");
 var highlightsModal = document.getElementById("highlights");
 var span = document.getElementsByClassName("close")[0];
@@ -2814,7 +2858,7 @@ function parsehighlightsresponse(responsetext) {
     }
     modaltext += "</ul>";
     highlightsModal.innerHTML = modaltext;
-    modal.style.display = "block"
+    openModal();
   } catch (e) {
     alert("Error processing highlights: " + e.message)
   }
@@ -2823,12 +2867,10 @@ function showhighlights(gamePk, gameDate) {
   makeGETRequest("` + http_root + `/highlights?gamePk=" + gamePk + "&gameDate=" + gameDate + "` + content_protect_b + `", parsehighlightsresponse);
   return false
 }
-span.onclick = function() {
-  modal.style.display = "none";
-}
+span.onclick = closeModal;
 `
 
-    body += 'window.onclick = function(event) { if (event.target == modal) { modal.style.display = "none"; } }</script>' + "\n"
+    body += 'window.onclick = function(event) { if (event.target == modal) {closeModal()} }</script>' + "\n"
 
     body += "</body></html>"
 

--- a/session.js
+++ b/session.js
@@ -3190,6 +3190,21 @@ class sessionClass {
     }
   }
 
+  // Get stylesheet from local file
+  async getCSS() {
+    this.debuglog('getCSS style.css')
+
+    let cssPath = path.join(__dirname, 'style.css')
+
+    if (fs.existsSync(cssPath)) {
+      this.debuglog('serving local stylesheet at ' + cssPath)
+      return fs.readFileSync(cssPath, 'utf8')
+    } else {
+      this.debuglog('failed to get stylesheet at ' + cssPath)
+      return
+    }
+  }
+
   // Get gameday data for a game (play and pitch data)
   async getGamedayData(gamePk) {
     try {

--- a/style.css
+++ b/style.css
@@ -1,0 +1,69 @@
+html,
+body {
+    display: block;
+    height: 100dvh;
+}
+
+.modal {
+    display: none;
+    position: fixed;
+    z-index: 9999;
+    inset: 0;
+
+    width: 100%;
+    height: 100%;
+
+    background-color: rgba(0, 0, 0, 0.4);
+
+    align-items: center;
+    justify-content: center;
+}
+
+.modal-content {
+    background-color: #fefefe;
+    border: 1px solid #888;
+    overflow-y: auto;
+    color: black;
+    box-sizing: border-box;
+
+    max-height: 90dvh;
+}
+
+#highlights {
+    overflow-y: auto;
+}
+
+#highlights a {
+    color: black;
+}
+
+.close {
+    color: black;
+    float: right;
+    font-size: 28px;
+    font-weight: bold;
+    padding-right: 5px;
+    cursor: pointer;
+}
+
+#highlights a:hover,
+#highlights a:focus,
+.close:hover,
+.close:focus {
+    color: gray;
+    text-decoration: none;
+    cursor: pointer;
+}
+
+@media screen and (max-width: 480px) {
+    .modal {
+        align-items: stretch;
+        justify-content: stretch;
+    }
+
+    .modal-content {
+        max-width: 100vw;
+        border-radius: 0;
+        overflow-y: auto;
+    }
+}

--- a/style.css
+++ b/style.css
@@ -25,7 +25,7 @@ body {
     overflow-y: auto;
     color: black;
     box-sizing: border-box;
-
+    padding:2px;
     max-height: 90dvh;
 }
 


### PR DESCRIPTION
It's more a preference thing, so I can imagine someone might think it's not necessary.

I watch condensed games a lot. In the highlight list, the condensed game is usually between the fourth-to-last and the last position. I always fret about spoiling myself what happened during the game while looking for the correct entry in the list. Also it's annoying to always search for the condensed game at the bottom.
(easy) Solution: Create an additional Condensed Game entry at the top of the highlights list.

In order to achieve this, the highlight list creation has become a function, that will be called twice. 
Once for the condensed game entry and a second time for the whole highlight list (including the condensed game).

Also the highlight list modal was expanded for additional 200px in width, so that every entry is displayed in full length.
I checked it with other games and never saw a line wrap.

During testing, for some reason Firefox started to assumed the response as XML type and gave me a warning. 
To avoid this warning, I declared the type as json.

<img width="997" height="696" alt="highlights" src="https://github.com/user-attachments/assets/bf94a359-4af8-4415-afdc-a958f5f09789" />